### PR TITLE
feat: Add batch processing

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,8 +15,8 @@ routes:
     name: allServer
     strategy: round-robin
     health_timeout_ms: 500
-    route_queue_size: 150
-    node_queue_size: 100
+    route_queue_size: 1000
+    node_queue_size: 500
     docker:
       image: node-server
       internal_port: 3000
@@ -25,7 +25,7 @@ routes:
       activation_interval_ms: 100
       cleanup_interval_ms: 5000
       inactive_size: 2
-      active_size: 4
+      active_size: 6
       max_active: 20
     servers:
     

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,7 +13,7 @@ emitter:
 routes:
   - path: /*
     name: allServer
-    strategy: least-connections
+    strategy: round-robin
     health_timeout_ms: 500
     route_queue_size: 150
     node_queue_size: 100

--- a/pkg/balancer/pool/heap.go
+++ b/pkg/balancer/pool/heap.go
@@ -1,0 +1,62 @@
+package pool
+
+import (
+	"container/heap"
+	"fmt"
+	"load-balancer/pkg/balancer/node"
+)
+
+func (h *NodeHeap) RemoveNode(target *node.Node) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i, n := range h.heap {
+		if n == target {
+			last := len(h.heap) - 1
+			h.heap[i] = h.heap[last]
+			h.heap = h.heap[:last]
+			if i < len(h.heap) {
+				heap.Fix(h, i)
+			}
+			return
+		}
+	}
+}
+
+func (h *NodeHeap) Len() int {
+	return len(h.heap)
+}
+
+func (h *NodeHeap) Less(i, j int) bool {
+	return (h.heap[i].Metrics.Connections + h.heap[i].Queue.Len()) < (h.heap[j].Metrics.Connections + h.heap[j].Queue.Len())
+}
+
+func (h *NodeHeap) Swap(i, j int) {
+	h.heap[i], h.heap[j] = h.heap[j], h.heap[i]
+}
+
+func (h *NodeHeap) Push(x any) {
+	h.heap = append(h.heap, x.(*node.Node))
+}
+
+func (h *NodeHeap) Pop() any {
+	old := h.heap
+	n := len(old)
+	x := old[n-1]
+	h.heap = old[0 : n-1]
+	return x
+}
+
+func (h *NodeHeap) Add(n *node.Node) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	heap.Push(h, n)
+}
+
+func (h *NodeHeap) RemoveMin() (*node.Node, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.Len() == 0 {
+		return nil, fmt.Errorf("cannot pop from empty heap")
+	}
+	return heap.Pop(h).(*node.Node), nil
+}

--- a/pkg/balancer/pool/init.go
+++ b/pkg/balancer/pool/init.go
@@ -1,10 +1,17 @@
 package pool
 
-import "load-balancer/pkg/balancer/node"
+import (
+	"container/heap"
+	"load-balancer/pkg/balancer/node"
+)
 
 func InitPool() *NodePool {
+	nodeHeap := &NodeHeap{}
+	heap.Init(nodeHeap)
+
 	return &NodePool{
 		Active:   make([]*node.Node, 0),
 		Inactive: make([]*node.Node, 0),
+		Heap:     nodeHeap,
 	}
 }

--- a/pkg/balancer/pool/pool.go
+++ b/pkg/balancer/pool/pool.go
@@ -62,17 +62,6 @@ func (p *NodePool) GetActive() []*node.Node {
 	return p.Active
 }
 
-func (p *NodePool) RemoveActive(n *node.Node) {
-	p.Mu.Lock()
-	defer p.Mu.Unlock()
-	for i, node := range p.Active {
-		if node == n {
-			p.Active = append(p.Active[:i], p.Active[i+1:]...)
-			break
-		}
-	}
-}
-
 func (p *NodePool) GetActiveSize() int {
 	p.Mu.Lock()
 	defer p.Mu.Unlock()
@@ -84,6 +73,7 @@ func (p *NodePool) AddActive(n *node.Node) {
 	defer p.Mu.Unlock()
 
 	p.Active = append(p.Active, n)
+	p.Heap.Push(n)
 }
 
 func (p *NodePool) UnpauseOne() error {
@@ -148,17 +138,6 @@ func (p *NodePool) GetInactive() []*node.Node {
 	return p.Inactive
 }
 
-func (p *NodePool) RemoveInactive(n *node.Node) {
-	p.Mu.Lock()
-	defer p.Mu.Unlock()
-	for i, node := range p.Inactive {
-		if node == n {
-			p.Inactive = append(p.Inactive[:i], p.Inactive[i+1:]...)
-			break
-		}
-	}
-}
-
 func (p *NodePool) GetInactiveSize() int {
 	p.Mu.Lock()
 	defer p.Mu.Unlock()
@@ -183,6 +162,7 @@ func (p *NodePool) unsafeRemoveActive(n *node.Node) {
 			break
 		}
 	}
+	p.Heap.RemoveNode(n)
 }
 
 // This method does not lock the `p.Mu` before performing
@@ -191,6 +171,7 @@ func (p *NodePool) unsafeRemoveActive(n *node.Node) {
 // Only use when the calling method acquires a lock
 func (p *NodePool) unsafeAddActive(n *node.Node) {
 	p.Active = append(p.Active, n)
+	p.Heap.Add(n)
 }
 
 // This method does not lock the `p.Mu` before performing

--- a/pkg/balancer/pool/strategies.go
+++ b/pkg/balancer/pool/strategies.go
@@ -50,11 +50,10 @@ func (p *NodePool) RoundRobin() *node.Node {
 }
 
 func (p *NodePool) LeastConnections() *node.Node {
-	var lowest *node.Node = nil
-	for _, n := range p.GetActive() {
-		if (lowest == nil || n.Queue.Len() < lowest.Queue.Len()) && n.Metrics.Health == "healthy" {
-			lowest = n
-		}
+	lowest, err := p.Heap.RemoveMin()
+	if err != nil {
+		logger.Err("Could not find node to proxy", fmt.Errorf("nodes length is 0"))
+		ws.EventEmitter.Error("Could not find node to proxy", fmt.Errorf("nodes length is 0"))
 	}
 	return lowest
 }

--- a/pkg/balancer/pool/types.go
+++ b/pkg/balancer/pool/types.go
@@ -8,5 +8,11 @@ import (
 type NodePool struct {
 	Active   []*node.Node
 	Inactive []*node.Node
+	Heap     *NodeHeap
 	Mu       sync.Mutex
+}
+
+type NodeHeap struct {
+	mu   sync.Mutex
+	heap []*node.Node
 }

--- a/pkg/balancer/route/queue.go
+++ b/pkg/balancer/route/queue.go
@@ -36,7 +36,9 @@ func (r *Route) WatchQueue() {
 				return
 			}
 
-			r.NodePool.Heap.Add(node)
+			if r.RouteConfig.Strategy == "least-connections" {
+				r.NodePool.Heap.Add(node)
+			}
 			load := r.CalculateLoad()
 			if load > 50 {
 				fmt.Println(load)

--- a/pkg/balancer/route/queue.go
+++ b/pkg/balancer/route/queue.go
@@ -36,6 +36,7 @@ func (r *Route) WatchQueue() {
 				return
 			}
 
+			r.NodePool.Heap.Add(node)
 			load := r.CalculateLoad()
 			if load > 50 {
 				fmt.Println(load)

--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -1,0 +1,27 @@
+package batch
+
+import (
+	"fmt"
+	"load-balancer/pkg/types"
+)
+
+func (b *Batch) Add(c *types.Connection) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(b.batch) == cap(b.batch) {
+		return fmt.Errorf("batch is at capacity")
+	}
+
+	b.batch = append(b.batch, c)
+	return nil
+}
+
+func (b *Batch) Flush() []*types.Connection {
+    b.mu.Lock()
+    defer b.mu.Unlock()
+
+    flushed := b.batch
+    b.batch = make([]*types.Connection, 0, b.cap)
+    return flushed
+}

--- a/pkg/batch/init.go
+++ b/pkg/batch/init.go
@@ -1,0 +1,10 @@
+package batch
+
+import "load-balancer/pkg/types"
+
+func InitBatch(cap int) *Batch {
+	return &Batch{
+		batch: make([]*types.Connection, 0, cap),
+		cap:   cap,
+	}
+}

--- a/pkg/batch/types.go
+++ b/pkg/batch/types.go
@@ -1,0 +1,12 @@
+package batch
+
+import (
+	"load-balancer/pkg/types"
+	"sync"
+)
+
+type Batch struct {
+	batch []*types.Connection
+	mu    sync.Mutex
+	cap   int
+}


### PR DESCRIPTION
This PR adds batch processing to the node queue. The heap seems to have also been added to this (oops!) Performance numbers are similar to previous, as shown below:

If anything, latency appears to be down.

```
peterolsen:~/projects/load-balancer$ wrk -t10 -c1700 -d5s http://localhost:8080
Running 5s test @ http://localhost:8080
  10 threads and 1700 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   160.33ms  163.05ms   1.47s    85.27%
    Req/Sec     1.22k   204.93     1.81k    69.18%
  59668 requests in 5.03s, 7.85MB read
Requests/sec:  11854.09
Transfer/sec:      1.56MB

peterolsen~/projects/load-balancer$ wrk -t10 -c1700 -d5s http://localhost:8080
Running 5s test @ http://localhost:8080
  10 threads and 1700 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   136.24ms  129.23ms   1.53s    85.85%
    Req/Sec     1.38k   190.60     1.92k    69.00%
  68733 requests in 5.10s, 9.05MB read
Requests/sec:  13486.45
Transfer/sec:      1.77MB

peterolsen:~/projects/load-balancer$ wrk -t10 -c1700 -d5s http://localhost:8080
Running 5s test @ http://localhost:8080
  10 threads and 1700 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   127.55ms  120.62ms   1.33s    85.99%
    Req/Sec     1.46k   189.85     2.09k    74.90%
  71543 requests in 5.03s, 9.42MB read
Requests/sec:  14219.20
Transfer/sec:      1.87MB
```