### PR TITLE
feat: add worker threads to node queue

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,7 @@ routes:
     health_timeout_ms: 500
     route_queue_size: 1000
     node_queue_size: 500
+    worker_threads: 30
     docker:
       image: node-server
       internal_port: 3000

--- a/pkg/balancer/node/init.go
+++ b/pkg/balancer/node/init.go
@@ -26,10 +26,9 @@ func FromContainer(containerID string, address string, routeConfig config.RouteC
 			ResponseTime: 0,
 			Connections:  0,
 		},
-		Queue: InitNodeQueue(routeConfig.NodeQueueSize),
+		Queue: InitNodeQueue(routeConfig.NodeQueueSize, routeConfig.WorkerThreads),
 	}
 
-	go out.CheckHealth()
 	go out.WatchQueue()
 	return out
 }
@@ -43,7 +42,7 @@ func FromURL(url string, routeConfig *config.RouteConfig) *Node {
 			ResponseTime: 0,
 			Connections:  0,
 		},
-		Queue: InitNodeQueue(routeConfig.NodeQueueSize),
+		Queue: InitNodeQueue(routeConfig.NodeQueueSize, routeConfig.WorkerThreads),
 	}
 
 	go out.CheckHealth()

--- a/pkg/balancer/node/types.go
+++ b/pkg/balancer/node/types.go
@@ -40,8 +40,10 @@ type NodeMetrics struct {
 }
 
 type NodeQueue struct {
-	Queue       chan *types.Connection // Channel-based queue
-	Open        bool                   // Indicates if the queue is open
-	connSignal  chan *types.Connection // Signal channel for new connections
-	closeSignal chan struct{}          // Signal channel for closing the queue
+	Queue         chan *types.Connection // Channel-based queue
+	Open          bool                   // Indicates if the queue is open
+	connChan      chan *types.Connection // Signal channel for new connections
+	closeSignal   chan struct{}          // Signal channel for closing the queue
+	workChan      chan *types.Connection // connections to send to the worker pool
+	workerThreads uint
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,7 @@ func setDefaultConfig() {
 				HealthTimeout:  5000,
 				RouteQueueSize: 50,
 				NodeQueueSize:  1000,
+				WorkerThreads:  10,
 				Docker: &DockerConfig{
 					Image:        "node-server",
 					InternalPort: 3000,

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -127,6 +127,9 @@ type RouteConfig struct {
 	// It is recommended to keep this high since requests dropped from the route queue will send a 500
 	RouteQueueSize uint `yaml:"route_queue_size"`
 
+	// The number of worker threads to be wathing a queue at a time
+	WorkerThreads uint `yaml:"worker_threads"`
+	
 	// Docker configuration, see DockerConfig type for more info
 	Docker *DockerConfig `yaml:"docker"`
 
@@ -135,4 +138,5 @@ type RouteConfig struct {
 
 	// List of pre-running servers to proxy requests to. See RouteServerConfig type for more info
 	Servers []RouteServerConfig `yaml:"servers"`
+
 }


### PR DESCRIPTION
Adds a worker thread pool and config variables to node queue. Also added a new `chan` the `nodeQueue` struct that the worker threads watch to pickup connections to handle. This greatly reduces the number of active goroutines, improving performance. See below:

```
peterolsen:~/projects/load-balancer$ wrk -t10 -c1700 -d5s http://localhost:8080
Running 5s test @ http://localhost:8080
  10 threads and 1700 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    99.18ms   39.50ms 537.64ms   71.62%
    Req/Sec     1.70k   393.71     2.34k    75.55%
  84713 requests in 5.10s, 11.15MB read
Requests/sec:  16607.55
Transfer/sec:      2.19MB
```