### PR TITLE
feat: requests skip route queue

### DIFF
--- a/pkg/balancer/handle_req.go
+++ b/pkg/balancer/handle_req.go
@@ -32,5 +32,11 @@ func (b *BalancerType) HandleRequest(conn *types.Connection) {
 		return
 	}
 
-	routeObject.Queue.Enqueue(conn)
+	proxyNode := routeObject.GetProxyNode(conn.Request.RemoteAddr)
+	if proxyNode != nil {
+		proxyNode.Queue.Enqueue(conn)
+	} else {
+		routeObject.Queue.Enqueue(conn)
+	}
+
 }

--- a/pkg/balancer/node/queue.go
+++ b/pkg/balancer/node/queue.go
@@ -104,3 +104,7 @@ func (n *Node) OpenQueue() {
 func (q *NodeQueue) Len() int {
 	return len(q.connChan)
 }
+
+func (q *NodeQueue) HasSpace() bool {
+	return len(q.connChan) < cap(q.connChan)
+}


### PR DESCRIPTION
### Description 📕

Skip using the route queue and go directly to the node queue. If no node is found, then add to the route queue.

### Performance Metrics 🚀

peterolsen:~/projects/load-balancer$ make test-wrk
wrk -t10 -c1000 -d10s http://localhost:8080
Running 10s test @ http://localhost:8080
  10 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    50.31ms   22.97ms 146.68ms   70.60%
    Req/Sec     1.99k   137.83     2.35k    72.70%
  198431 requests in 10.05s, 26.11MB read
Requests/sec:  19743.10
Transfer/sec:      2.60MB