### PR TITLE
feat: make batch take ownership of flushing

### DIFF
--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -1,27 +1,60 @@
 package batch
 
-import (
-	"fmt"
-	"load-balancer/pkg/types"
-)
-
-func (b *Batch) Add(c *types.Connection) error {
+// Adds an item to the batch
+//
+// If the batch is full, flush it
+func (b *Batch[T]) Add(item T) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if len(b.batch) == cap(b.batch) {
-		return fmt.Errorf("batch is at capacity")
+	if len(b.batch) == cap(b.batch)-1 {
+		b.batch = append(b.batch, item)
+		b.flushUnsafe()
+		return
 	}
 
-	b.batch = append(b.batch, c)
-	return nil
+	b.batch = append(b.batch, item)
 }
 
-func (b *Batch) Flush() []*types.Connection {
-    b.mu.Lock()
-    defer b.mu.Unlock()
+// Same as flush method but with no locking.
+//
+// Done to avoid deadlock in the add method when we add + flush
+func (b *Batch[T]) flushUnsafe() {
+	//apply flush func
+	flushed := b.batch
+	for _, item := range flushed {
+		b.onFlush(item)
+	}
 
-    flushed := b.batch
-    b.batch = make([]*types.Connection, 0, b.cap)
-    return flushed
+	b.batch = make([]T, 0, b.cap)
+}
+
+// The flush method applies the `onFlush` function to every item that was in the batch.
+//
+// Once this is done, reset the batch to have no members in it
+func (b *Batch[T]) Flush() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.flushUnsafe()
+}
+
+// This method is basically the same as Flush, but the user can provide
+// a custom method to be applied to eveyr item
+func (b *Batch[T]) FlushCustom(onFlush func(T)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	//apply custom flush func
+	flushed := b.batch
+	for _, item := range flushed {
+		onFlush(item)
+	}
+
+	b.batch = make([]T, 0, b.cap)
+}
+
+// Close the batch. All tickers and channels will be closed
+func (b *Batch[T]) Close() {
+	b.closeChan <- struct{}{}
 }

--- a/pkg/batch/init.go
+++ b/pkg/batch/init.go
@@ -1,10 +1,35 @@
 package batch
 
-import "load-balancer/pkg/types"
+import "time"
 
-func InitBatch(cap uint32) *Batch {
-	return &Batch{
-		batch: make([]*types.Connection, 0, cap),
-		cap:   cap,
+func InitBatch[T any](cap uint32, flushInterval time.Duration, onFlush func(T)) *Batch[T] {
+	b := &Batch[T]{
+		batch:     make([]T, 0, cap),
+		cap:       cap,
+		onFlush:   onFlush,
+		fullChan:  make(chan struct{}),
+		closeChan: make(chan struct{}),
 	}
+
+	batchTicker := time.NewTicker(flushInterval)
+	go func() {
+		for {
+			select {
+			// batch has closed, flush all items and close channels
+			case <-b.closeChan:
+				b.Flush()
+				batchTicker.Stop()
+				close(b.closeChan)
+				close(b.fullChan)
+				return
+
+			// ticker went off or batch is full. flush those items!
+			case <-b.fullChan:
+			case <-batchTicker.C:
+				b.Flush()
+			}
+		}
+	}()
+
+	return b
 }

--- a/pkg/batch/types.go
+++ b/pkg/batch/types.go
@@ -1,12 +1,28 @@
 package batch
 
 import (
-	"load-balancer/pkg/types"
 	"sync"
 )
 
-type Batch struct {
-	batch []*types.Connection
-	mu    sync.Mutex
-	cap   uint32
+type Batch[T any] struct {
+	// The underlying sice that holds batch data
+	batch []T
+
+	// Mutex for safe locking of slice in goroutines
+	mu sync.Mutex
+
+	// Capacity of the batch, need to keep track for when batch is reset
+	cap uint32
+
+	// Signal when the batch is full, will be emptied after
+	fullChan chan struct{}
+
+	// Signal when the batch is closed
+	closeChan chan struct{}
+
+	// Function passed in from the init method
+	//
+	// When flushing, this function will be applied to all
+	// members of the batch
+	onFlush func(T)
 }

--- a/pkg/workerpool/init.go
+++ b/pkg/workerpool/init.go
@@ -16,9 +16,5 @@ func InitWorkerPool[T any](numWorkers uint16, eventHandler func(e T)) WorkerPool
 		}()
 	}
 
-	return WorkerPool[T]{
-		numWorkers:   numWorkers,
-		eventChan:    make(chan T, 1000),
-		eventHandler: eventHandler,
-	}
+	return pool
 }


### PR DESCRIPTION
### Description 📕

The `batch` pkg now takes ownership of flushing. Methods are still accessible for users to flush when desired, but all you need to do is pass it a timeout and a max capacity and it does its thing.

### Performance Metrics 🚀

Not really a performance change, but I was proud of this one (on my mac even)

```
peterolsen ~/Desktop/cs/projects/load-balancer $ make test-wrk
wrk -t10 -c1000 -d5s http://localhost:8080
Running 5s test @ http://localhost:8080
  10 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    50.14ms   28.48ms 180.20ms   76.47%
    Req/Sec     2.06k   402.28     2.84k    76.60%
  102742 requests in 5.02s, 13.52MB read
Requests/sec:  20479.13
Transfer/sec:      2.70MB
```