### PR TITLE
feat: add worker pool + batch to logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ test:
 test-rps:
 	go run ./test/main.go -seconds=${SECONDS} -rps=${RPS}
 
-lint:
-	golangci-lint run -v --config .golangci.yml
-
 test-wrk:
 	wrk -t10 -c1000 -d10s http://localhost:8080
+
+up-fds:
+	ulimit -n $((1 << 16))
 
 clean:
 	rm -rf ./logs

--- a/pkg/balancer/node/queue.go
+++ b/pkg/balancer/node/queue.go
@@ -9,8 +9,10 @@ import (
 
 func (n *Node) WatchQueue() {
 	q := n.Queue
-	batch := batch.InitBatch(100, 20*time.Millisecond, func(conn *types.Connection) {
-		q.workerPool.Event(conn)
+	batch := batch.InitBatch(100, 20*time.Millisecond, func(conns []*types.Connection) {
+		for _, conn := range conns {
+			q.workerPool.Event(conn)
+		}
 	})
 
 	for {
@@ -28,8 +30,10 @@ func (n *Node) WatchQueue() {
 				}
 				go n.processRequest(conn)
 			}
-			batch.FlushCustom(func(conn *types.Connection) {
-				go n.processRequest(conn)
+			batch.FlushCustom(func(conns []*types.Connection) {
+				for _, conn := range conns {
+					go n.processRequest(conn)
+				}
 			})
 
 			batch.Close()

--- a/pkg/balancer/node/types.go
+++ b/pkg/balancer/node/types.go
@@ -51,5 +51,5 @@ type NodeQueue struct {
 	open        bool                   // Indicates if the queue is open
 	connChan    chan *types.Connection // Signal channel for new connections
 	closeSignal chan struct{}          // Signal channel for closing the queue
-	workerPool  workerpool.WorkerPool[*types.Connection]
+	workerPool  *workerpool.WorkerPool[*types.Connection]
 }

--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -20,11 +20,9 @@ func (b *Batch[T]) Add(item T) {
 //
 // Done to avoid deadlock in the add method when we add + flush
 func (b *Batch[T]) flushUnsafe() {
-	//apply flush func
-	flushed := b.batch
-	for _, item := range flushed {
-		b.onFlush(item)
-	}
+	//copy batch and apply fush function
+	batchCopy := append([]T(nil), b.batch...)
+	b.onFlush(batchCopy)
 
 	b.batch = make([]T, 0, b.cap)
 }
@@ -41,15 +39,13 @@ func (b *Batch[T]) Flush() {
 
 // This method is basically the same as Flush, but the user can provide
 // a custom method to be applied to eveyr item
-func (b *Batch[T]) FlushCustom(onFlush func(T)) {
+func (b *Batch[T]) FlushCustom(onFlush func([]T)) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	//apply custom flush func
-	flushed := b.batch
-	for _, item := range flushed {
-		onFlush(item)
-	}
+	batchCopy := append([]T(nil), b.batch...)
+	onFlush(batchCopy)
 
 	b.batch = make([]T, 0, b.cap)
 }

--- a/pkg/batch/init.go
+++ b/pkg/batch/init.go
@@ -2,7 +2,7 @@ package batch
 
 import "time"
 
-func InitBatch[T any](cap uint32, flushInterval time.Duration, onFlush func(T)) *Batch[T] {
+func InitBatch[T any](cap uint32, flushInterval time.Duration, onFlush func([]T)) *Batch[T] {
 	b := &Batch[T]{
 		batch:     make([]T, 0, cap),
 		cap:       cap,

--- a/pkg/batch/types.go
+++ b/pkg/batch/types.go
@@ -24,5 +24,5 @@ type Batch[T any] struct {
 	//
 	// When flushing, this function will be applied to all
 	// members of the batch
-	onFlush func(T)
+	onFlush func([]T)
 }

--- a/pkg/logger/types.go
+++ b/pkg/logger/types.go
@@ -1,6 +1,11 @@
 package logger
 
-import "sync"
+import (
+	"load-balancer/pkg/batch"
+	"load-balancer/pkg/workerpool"
+	"os"
+	"sync"
+)
 
 type LogLevel uint8
 
@@ -17,6 +22,9 @@ type Logger struct {
 	maxLines     uint32
 	linesWritten uint32
 	logFile      string
+	logFileRef   *os.File
 	logLevel     uint8
 	logDir       string
+	logBatch     *batch.Batch[string]
+	workerPool   *workerpool.WorkerPool[string]
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -27,6 +27,8 @@ func main() {
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		<-c
+		logger.CleanupLogger()
+
 		fmt.Println("Cleaning up nodes...")
 		err := balancer.Balancer.CleanupNodes()
 		if err != nil {

--- a/pkg/workerpool/init.go
+++ b/pkg/workerpool/init.go
@@ -1,6 +1,6 @@
 package workerpool
 
-func InitWorkerPool[T any](numWorkers uint16, eventHandler func(e T)) WorkerPool[T] {
+func InitWorkerPool[T any](numWorkers uint16, eventHandler func(e T)) *WorkerPool[T] {
 	pool := WorkerPool[T]{
 		numWorkers:   numWorkers,
 		eventChan:    make(chan T, 1000),
@@ -16,5 +16,5 @@ func InitWorkerPool[T any](numWorkers uint16, eventHandler func(e T)) WorkerPool
 		}()
 	}
 
-	return pool
+	return &pool
 }


### PR DESCRIPTION
### Description 📕

Adds a worker pool and batch to the logger. This is done for light performance benefits, probably very minimal.

### Performance Metrics 🚀
```
peterolsen:~/projects/load-balancer$ make test-wrk
wrk -t10 -c1000 -d10s http://localhost:8080
Running 10s test @ http://localhost:8080
  10 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    50.86ms   21.65ms 151.39ms   68.49%
    Req/Sec     1.98k   117.48     2.37k    67.20%
  197201 requests in 10.05s, 25.95MB read
Requests/sec:  19615.77
Transfer/sec:      2.58MB
```